### PR TITLE
Prevents PlatformException on Android

### DIFF
--- a/lib/flutter_inappbrowser.dart
+++ b/lib/flutter_inappbrowser.dart
@@ -488,6 +488,7 @@ class ChromeSafariBrowser {
     args.putIfAbsent('options', () => options);
     args.putIfAbsent('optionsFallback', () => optionsFallback);
     args.putIfAbsent('useChromeSafariBrowser', () => true);
+    args.putIfAbsent('isData', () => false);
     await _ChannelManager.channel.invokeMethod('open', args);
     this._isOpened = true;
   }


### PR DESCRIPTION
Otherwise the following exception is thrown: PlatformException(error, Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference, null).