### PR TITLE
[fix] encode resourceURL

### DIFF
--- a/ios/Classes/InAppBrowserWebViewController.swift
+++ b/ios/Classes/InAppBrowserWebViewController.swift
@@ -746,7 +746,9 @@ class InAppBrowserWebViewController: UIViewController, UIScrollViewDelegate, WKU
         }
         else if message.name == "resourceLoaded" && (webViewOptions?.useOnLoadResource)! {
             if let resource = convertToDictionary(text: message.body as! String) {
-                let url = URL(string: resource["name"] as! String)!
+                let rawUrl = resource["name"] as! String
+                let encodedUrl = rawUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+                let url = URL(string: encodedUrl)!
                 if !UIApplication.shared.canOpenURL(url) {
                     return
                 }


### PR DESCRIPTION
# What is the problem?

<img width="1095" alt="2018-12-18 16 29 56" src="https://user-images.githubusercontent.com/6331737/50138534-3feef480-02e2-11e9-823a-46aae63f6ded.png">

a Fatal error occurs when a resource url has some unescaped characters which must be escaped before unwrapping.
For example, `https://fonts.googleapis.com/css?family=Google+Sans:400,500|Roboto:300,400,500|Roboto+Mono:400,700|Material+Icons`.

I encounted the error when I tried to run [the InAppBrowser example code](https://github.com/pichillilorenzo/flutter_inappbrowser#inappwebview-class).

# What is my solution?

encoding urls before unwrapping.

# my environment
```
Flutter 1.1.2-pre.39 • channel master • https://github.com/flutter/flutter.git
Framework • revision 0e9ad43416 (34 hours ago) • 2018-12-16 16:39:28 -0500
Engine • revision 4941125829
Tools • Dart 2.2.0 (build 2.2.0-dev.1.1 f9ebf21297)
```
