### PR TITLE
bug fix for android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,6 @@ android {
 dependencies {
     implementation 'androidx.webkit:webkit:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
 }


### PR DESCRIPTION
Android dependency 'androidx.core:core' has different version for the compile (1.0.0) and runtime (1.0.1) classpath