### PR TITLE
The 'open' method requires an options dictionary

### DIFF
--- a/lib/flutter_inappbrowser.dart
+++ b/lib/flutter_inappbrowser.dart
@@ -294,6 +294,7 @@ class InAppBrowser {
     args.putIfAbsent('isData', () => false);
     args.putIfAbsent('openWithSystemBrowser', () => true);
     args.putIfAbsent('useChromeSafariBrowser', () => false);
+    args.putIfAbsent('options', () => {});
     return await _ChannelManager.channel.invokeMethod('open', args);
   }
 


### PR DESCRIPTION
Otherwise, SwiftFlutterPlugin.swift throws an exception on line 285
when the InAppBrowser.openWithSystemBrowser(url) method is called:

  let options = (arguments["options"] as? [String: Any])!