### PR TITLE
Adds a transparentBackground option for iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ All platforms support:
   - __javaScriptEnabled__: Set to `true` to enable JavaScript. The default value is `true`.
   - __javaScriptCanOpenWindowsAutomatically__: Set to `true` to allow JavaScript open windows without user interaction. The default value is `false`.
   - __mediaPlaybackRequiresUserGesture__: Set to `true` to prevent HTML5 audio or video from autoplaying. The default value is `true`.
+  - __transparentBackground__: Set to `true` to make the background of the WebView transparent. If your app has a dark theme, this can prevent a white flash on initialization. The default value is `false`.
 
   **Android** supports these additional options:
 

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappbrowser/InAppWebView/InAppWebView.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappbrowser/InAppWebView/InAppWebView.java
@@ -3,6 +3,7 @@ package com.pichillilorenzo.flutter_inappbrowser.InAppWebView;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Picture;
 import android.os.Build;
 import android.util.AttributeSet;
@@ -183,6 +184,10 @@ public class InAppWebView extends WebView {
     settings.setUseWideViewPort(options.useWideViewPort);
     settings.setSupportZoom(options.supportZoom);
     settings.setTextZoom(options.textZoom);
+
+    if (options.transparentBackground) {
+      setBackgroundColor(Color.TRANSPARENT);
+    }
   }
 
   public void loadUrl(String url, MethodChannel.Result result) {

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappbrowser/InAppWebView/InAppWebViewOptions.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappbrowser/InAppWebView/InAppWebViewOptions.java
@@ -22,5 +22,5 @@ public class InAppWebViewOptions extends Options {
   public boolean domStorageEnabled = false;
   public boolean useWideViewPort = true;
   public boolean safeBrowsingEnabled = true;
-
+  public boolean transparentBackground = false;
 }

--- a/ios/Classes/InAppWebView.swift
+++ b/ios/Classes/InAppWebView.swift
@@ -113,6 +113,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
         configuration.userContentController = WKUserContentController()
         configuration.preferences = WKPreferences()
         
+        if (options?.transparentBackground)! {
+            isOpaque = false
+            backgroundColor = UIColor.clear
+            scrollView.backgroundColor = UIColor.clear
+        }
+
         // prevent webView from bouncing
         if (options?.disallowOverScroll)! {
             if responds(to: #selector(getter: scrollView)) {

--- a/ios/Classes/InAppWebViewOptions.swift
+++ b/ios/Classes/InAppWebViewOptions.swift
@@ -28,6 +28,7 @@ public class InAppWebViewOptions: Options {
     var ignoresViewportScaleLimits = false
     var allowsInlineMediaPlayback = false
     var allowsPictureInPictureMediaPlayback = true
+    var transparentBackground = false
     
     override init(){
         super.init()

--- a/lib/flutter_inappbrowser.dart
+++ b/lib/flutter_inappbrowser.dart
@@ -171,6 +171,7 @@ class InAppBrowser {
   ///    - __toolbarTopBackgroundColor__: Set the custom background color of the toolbar at the top.
   ///    - __hideUrlBar__: Set to `true` to hide the url bar on the toolbar at the top. The default value is `false`.
   ///    - __mediaPlaybackRequiresUserGesture__: Set to `true` to prevent HTML5 audio or video from autoplaying. The default value is `true`.
+  ///    - __transparentBackground__: Set to `true` to make the background of the WebView transparent. If your app has a dark theme, this can prevent a white flash on initialization. The default value is `false`.
   ///
   ///  - **Android** supports these additional options:
   ///


### PR DESCRIPTION
This is useful to prevent a brief white flash on initialization
for apps that use a dark theme.