### PR TITLE
Remove async call in close

### DIFF
--- a/ios/Classes/InAppBrowserWebViewController.swift
+++ b/ios/Classes/InAppBrowserWebViewController.swift
@@ -272,27 +272,21 @@ class InAppBrowserWebViewController: UIViewController, UIScrollViewDelegate, WKU
         
         weak var weakSelf = self
         
-        // Run later to avoid the "took a long time" log message.
-        DispatchQueue.main.async(execute: {() -> Void in
-            if (weakSelf?.responds(to: #selector(getter: self.presentingViewController)))! {
-                weakSelf?.presentingViewController?.dismiss(animated: true, completion: {() -> Void in
-                    self.tmpWindow?.windowLevel = 0.0
-                    UIApplication.shared.delegate?.window??.makeKeyAndVisible()
-                    if (self.navigationDelegate != nil) {
-                        self.navigationDelegate?.browserExit(uuid: self.uuid)
-                    }
-                })
-            }
-            else {
-                weakSelf?.parent?.dismiss(animated: true, completion: {() -> Void in
-                    self.tmpWindow?.windowLevel = 0.0
-                    UIApplication.shared.delegate?.window??.makeKeyAndVisible()
-                    if (self.navigationDelegate != nil) {
-                        self.navigationDelegate?.browserExit(uuid: self.uuid)
-                    }
-                })
-            }
-        })
+        if (weakSelf?.responds(to: #selector(getter: self.presentingViewController)))! {
+            weakSelf?.presentingViewController?.dismiss(animated: true, completion: {() -> Void in
+                self.tmpWindow?.windowLevel = 0.0
+                UIApplication.shared.delegate?.window??.makeKeyAndVisible()
+            })
+        }
+        else {
+            weakSelf?.parent?.dismiss(animated: true, completion: {() -> Void in
+                self.tmpWindow?.windowLevel = 0.0
+                UIApplication.shared.delegate?.window??.makeKeyAndVisible()
+            })
+        }
+        if (self.navigationDelegate != nil) {
+            self.navigationDelegate?.browserExit(uuid: self.uuid)
+        }
     }
     
     @objc func goBack() {


### PR DESCRIPTION
Because the call is async, our inAppBrowser might report itself as closed before its actually closed. This can cause issues when closing a browser and then opening a browser in quick succession. Also moved browserExit after of the dismiss call, as if presentingViewController is nil, onExit should still be called.