### PR TITLE
Resolving gradle error.

### DIFF
--- a/android/src/main/res/menu/menu_main.xml
+++ b/android/src/main/res/menu/menu_main.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:appcompat="http://schemas.android.com/apk/res-auto"
-    xmlns:app="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".InAppBrowserActivity">
 


### PR DESCRIPTION
This version of flutter_inappbrowser (1.2.1) breaks the gradle build, because the wrong link is set.