### PR TITLE
- added a shared WKProcessPool for webview instances

### DIFF
--- a/ios/Classes/FlutterWebViewController.swift
+++ b/ios/Classes/FlutterWebViewController.swift
@@ -28,7 +28,7 @@ public class FlutterWebViewController: NSObject, FlutterPlatformView {
         
         let options = InAppWebViewOptions()
         options.parse(options: initialOptions)
-        let preWebviewConfiguration = InAppWebView.preWKWebViewConfiguration(options: options)
+        let preWebviewConfiguration = InAppWebView.preWKWebViewConfiguration(options: options, webViewProcessPool: SwiftFlutterPlugin.webViewProcessPool)
         
         webView = InAppWebView(frame: frame, configuration: preWebviewConfiguration, IABController: nil, IAWController: self)
         let channelName = "com.pichillilorenzo/flutter_inappwebview_" + String(viewId)

--- a/ios/Classes/InAppBrowserWebViewController.swift
+++ b/ios/Classes/InAppBrowserWebViewController.swift
@@ -113,7 +113,7 @@ class InAppBrowserWebViewController: UIViewController, UIScrollViewDelegate, WKU
     
     override func viewWillAppear(_ animated: Bool) {
         if !viewPrepared {
-            let preWebviewConfiguration = InAppWebView.preWKWebViewConfiguration(options: webViewOptions)
+            let preWebviewConfiguration = InAppWebView.preWKWebViewConfiguration(options: webViewOptions, webViewProcessPool: SwiftFlutterPlugin.webViewProcessPool)
             self.webView = InAppWebView(frame: .zero, configuration: preWebviewConfiguration, IABController: self, IAWController: nil)
             self.containerWebView.addSubview(self.webView)
             prepareConstraints()

--- a/ios/Classes/InAppWebView.swift
+++ b/ios/Classes/InAppWebView.swift
@@ -191,8 +191,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate, WKNavi
         }
     }
     
-    public static func preWKWebViewConfiguration(options: InAppWebViewOptions?) -> WKWebViewConfiguration {
+    public static func preWKWebViewConfiguration(options: InAppWebViewOptions?, webViewProcessPool: WKProcessPool) -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
+        configuration.processPool = webViewProcessPool
         
         if #available(iOS 10.0, *) {
             configuration.mediaTypesRequiringUserActionForPlayback = ((options?.mediaPlaybackRequiresUserGesture)!) ? .all : []

--- a/ios/Classes/SwiftFlutterPlugin.swift
+++ b/ios/Classes/SwiftFlutterPlugin.swift
@@ -38,6 +38,7 @@ public class SwiftFlutterPlugin: NSObject, FlutterPlugin {
     static var registrar: FlutterPluginRegistrar?
     static var channel: FlutterMethodChannel?
     
+    static let webViewProcessPool: WKProcessPool = WKProcessPool()
     var webViewControllers: [String: InAppBrowserWebViewController?] = [:]
     var safariViewControllers: [String: Any?] = [:]
     


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #196, #152 

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes

We discovered that CookieManager fails to set cookies on iOS 11 and on iOS 12 it's working only before you are opening a webview. After that, if you want to set again some new cookies, the cookie store doesn't take care of them.

After hours of searches, we found out that there is a bug on older iOS versions and you need to use a shared WKProcessPool for your webviews - [https://link.medium.com/VUNloIbpI1](url) [https://forums.developer.apple.com/thread/99674](url).

<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->


## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
